### PR TITLE
Add sparkfun_pico to include path

### DIFF
--- a/sparkfun_pico/CMakeLists.txt
+++ b/sparkfun_pico/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(
               ${CMAKE_CURRENT_LIST_DIR}/tlsf/tlsf_common.h
               ${CMAKE_CURRENT_LIST_DIR}/tlsf/tlsf_block_functions.h)
 
+target_include_directories(sparkfun_pico INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
 # Are we wrapping the built in alloc functions?
 if (SFE_PICO_ALLOC_WRAP)
     pico_wrap_function(sparkfun_pico malloc)


### PR DESCRIPTION
This way the whole repository can be added as a submodule, imported using `add_subdirectory` and then easily included as `#include <sfe_pico.h>` :slightly_smiling_face: 